### PR TITLE
Ensure boot ISO is attached on lowest numbered port, relative to other ISOs

### DIFF
--- a/builder/virtualbox/common/step_attach_isos.go
+++ b/builder/virtualbox/common/step_attach_isos.go
@@ -81,11 +81,11 @@ func (s *StepAttachISOs) Run(ctx context.Context, state multistep.StateBag) mult
 			device = 1
 			if s.ISOInterface == "sata" {
 				controllerName = "SATA Controller"
-				port = 15
+				port = 13
 				device = 0
 			} else if s.ISOInterface == "virtio" {
 				controllerName = "VirtIO Controller"
-				port = 15
+				port = 13
 				device = 0
 			}
 			ui.Message("Mounting boot ISO...")
@@ -109,11 +109,11 @@ func (s *StepAttachISOs) Run(ctx context.Context, state multistep.StateBag) mult
 			device = 1
 			if s.ISOInterface == "sata" {
 				controllerName = "SATA Controller"
-				port = 13
+				port = 15
 				device = 0
 			} else if s.ISOInterface == "virtio" {
 				controllerName = "VirtIO Controller"
-				port = 13
+				port = 15
 				device = 0
 			}
 			ui.Message("Mounting cd_files ISO...")


### PR DESCRIPTION
Ensure boot ISO is attached on lowest numbered port, relative to other ISOs

When instructed to boot from CD, the virtualbox boot code searches the
controllers ports from low to high for an attached CD drive. It stops at the
first CD drive it finds. If this isn't a bootable ISO, then attempting to boot
from CD fails - it does not continue to try other ports. Therefore the boot ISO
must be the first ISO the boot code encounters.

Closes #31
Closes #20

