### PR TITLE
add support for OutputDir variable in vboxmanage commands

### DIFF
--- a/builder/virtualbox/common/step_vboxmanage.go
+++ b/builder/virtualbox/common/step_vboxmanage.go
@@ -17,6 +17,9 @@ type commandTemplate struct {
 	// HTTPPort is the HTTP server port.
 	HTTPPort int
 
+	// Output Directory
+	OutputDir string
+
 	Name string
 }
 
@@ -30,8 +33,9 @@ type commandTemplate struct {
 //
 // Produces:
 type StepVBoxManage struct {
-	Commands [][]string
-	Ctx      interpolate.Context
+	Commands  [][]string
+	Ctx       interpolate.Context
+	OutputDir string
 }
 
 func (s *StepVBoxManage) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -47,9 +51,10 @@ func (s *StepVBoxManage) Run(ctx context.Context, state multistep.StateBag) mult
 	httpPort := state.Get("http_port").(int)
 
 	s.Ctx.Data = &commandTemplate{
-		Name:     vmName,
-		HTTPIP:   hostIP,
-		HTTPPort: httpPort,
+		Name:      vmName,
+		HTTPIP:    hostIP,
+		HTTPPort:  httpPort,
+		OutputDir: s.OutputDir,
 	}
 
 	for _, originalCommand := range s.Commands {

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -435,8 +435,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SkipNatMapping: b.config.SkipNatMapping,
 		},
 		&vboxcommon.StepVBoxManage{
-			Commands: b.config.VBoxManage,
-			Ctx:      b.config.ctx,
+			Commands:  b.config.VBoxManage,
+			Ctx:       b.config.ctx,
+			OutputDir: b.config.OutputDir,
 		},
 		&vboxcommon.StepRun{
 			Headless: b.config.Headless,

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -110,8 +110,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SkipNatMapping: b.config.SkipNatMapping,
 		},
 		&vboxcommon.StepVBoxManage{
-			Commands: b.config.VBoxManage,
-			Ctx:      b.config.ctx,
+			Commands:  b.config.VBoxManage,
+			Ctx:       b.config.ctx,
+			OutputDir: b.config.OutputDir,
 		},
 		&vboxcommon.StepRun{
 			Headless: b.config.Headless,

--- a/builder/virtualbox/vm/builder.go
+++ b/builder/virtualbox/vm/builder.go
@@ -94,8 +94,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SkipNatMapping: b.config.SkipNatMapping,
 		},
 		&vboxcommon.StepVBoxManage{
-			Commands: b.config.VBoxManage,
-			Ctx:      b.config.ctx,
+			Commands:  b.config.VBoxManage,
+			Ctx:       b.config.ctx,
+			OutputDir: b.config.OutputDir,
 		},
 		&vboxcommon.StepRun{
 			Headless: b.config.Headless,


### PR DESCRIPTION
this is particularly useful if one would like to do something
exotic such attaching new virtual disks to different types
of controllers and would like to place the images in the
same output directory as the images packer created itself
