### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/builder/virtualbox/common/guest_additions_config.go
+++ b/builder/virtualbox/common/guest_additions_config.go
@@ -33,7 +33,7 @@ type GuestAdditionsConfig struct {
 	//  where the VirtualBox guest additions ISO will be uploaded. By default this
 	//  is `VBoxGuestAdditions.iso` which should upload into the login directory of
 	//  the user. This is a [configuration
-	//  template](/docs/templates/legacy_json_templates/engine) where the `Version`
+	//  template](/packer/docs/templates/legacy_json_templates/engine) where the `Version`
 	//  variable is replaced with the VirtualBox version.
 	GuestAdditionsPath string `mapstructure:"guest_additions_path"`
 	// The SHA256 checksum of the guest

--- a/builder/virtualbox/common/vboxmanage_config.go
+++ b/builder/virtualbox/common/vboxmanage_config.go
@@ -37,7 +37,7 @@ type VBoxManageConfig struct {
 	// followed by the CPUs.
 	// Each command itself is an array of strings, where each string is an argument to
 	// `VBoxManage`. Each argument is treated as a [configuration
-	// template](/docs/templates/legacy_json_templates/engine). The only available
+	// template](/packer/docs/templates/legacy_json_templates/engine). The only available
 	// variable is `Name` which is replaced with the unique name of the VM, which is
 	// required for many VBoxManage calls.
 	VBoxManage [][]string `mapstructure:"vboxmanage" required:"false"`

--- a/docs-partials/builder/virtualbox/common/GuestAdditionsConfig-not-required.mdx
+++ b/docs-partials/builder/virtualbox/common/GuestAdditionsConfig-not-required.mdx
@@ -17,7 +17,7 @@
    where the VirtualBox guest additions ISO will be uploaded. By default this
    is `VBoxGuestAdditions.iso` which should upload into the login directory of
    the user. This is a [configuration
-   template](/docs/templates/legacy_json_templates/engine) where the `Version`
+   template](/packer/docs/templates/legacy_json_templates/engine) where the `Version`
    variable is replaced with the VirtualBox version.
 
 - `guest_additions_sha256` (string) - The SHA256 checksum of the guest

--- a/docs-partials/builder/virtualbox/common/VBoxManageConfig-not-required.mdx
+++ b/docs-partials/builder/virtualbox/common/VBoxManageConfig-not-required.mdx
@@ -25,7 +25,7 @@
   followed by the CPUs.
   Each command itself is an array of strings, where each string is an argument to
   `VBoxManage`. Each argument is treated as a [configuration
-  template](/docs/templates/legacy_json_templates/engine). The only available
+  template](/packer/docs/templates/legacy_json_templates/engine). The only available
   variable is `Name` which is replaced with the unique name of the VM, which is
   required for many VBoxManage calls.
 

--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -16,19 +16,19 @@ Packer actually comes with multiple builders able to create VirtualBox
 machines, depending on the strategy you want to use to build the image. Packer
 supports the following VirtualBox builders:
 
-- [virtualbox-iso](/docs/builders/virtualbox-iso) - Starts from an ISO
+- [virtualbox-iso](/packer/plugins/builders/virtualbox/iso) - Starts from an ISO
   file, creates a brand new VirtualBox VM, installs an OS, provisions
   software within the OS, then exports that machine to create an image. This
   is best for people who want to start from scratch.
 
-- [virtualbox-ovf](/docs/builders/virtualbox-ovf) - This builder imports
+- [virtualbox-ovf](/packer/plugins/builders/virtualbox/ovf) - This builder imports
   an existing OVF/OVA file, runs provisioners on top of that VM, and exports
   that machine to create an image. This is best if you have an existing
   VirtualBox VM export you want to use as the source. As an additional
   benefit, you can feed the artifact of this builder back into itself to
   iterate on a machine.
 
-- [virtualbox-vm](/docs/builders/virtualbox-vm) - This builder uses an
+- [virtualbox-vm](/packer/plugins/builders/virtualbox/vm) - This builder uses an
   existing VM to run defined provisioners on top of that VM, and optionally
   creates a snapshot to save the changes applied from the provisioners. In
   addition the builder is able to export that machine to create an image. The
@@ -39,7 +39,7 @@ supports the following VirtualBox builders:
 ## How to use this plugin
 
 From Packer v1.7.0, copy and paste this code into your Packer configuration to install this plugin.
-Then, run [`packer init`](/docs/commands/init).
+Then, run [`packer init`](/packer/docs/commands/init).
 
 ```hcl
 packer {

--- a/docs/builders/vm.mdx
+++ b/docs/builders/vm.mdx
@@ -101,7 +101,7 @@ references for [ISO](#iso-configuration),
 configuration references, which are
 necessary for this build to succeed and can be found further down the page.
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder.
 
 ### Required:


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them