### PR TITLE
Fix documentation for rtc_time_base

### DIFF
--- a/docs-partials/builder/virtualbox/iso/Config-not-required.mdx
+++ b/docs-partials/builder/virtualbox/iso/Config-not-required.mdx
@@ -13,8 +13,8 @@
   When set to false, nested virtualisation is disabled. This is the default.
 
 - `rtc_time_base` (string) - RTC time base: UTC or local.
-  When set to true, the RTC is set as UTC time.
-  When set to false, the RTC is set as local time. This is the default.
+  When set to "UTC", the RTC is set as UTC time.
+  When set to "local", the RTC is set as local time. This is the default.
 
 - `disk_size` (uint) - The size, in megabytes, of the hard disk to create for the VM. By
   default, this is 40000 (about 40 GB).


### PR DESCRIPTION
The documentation here is incorrect: https://developer.hashicorp.com/packer/plugins/builders/virtualbox/iso#rtc_time_base

When you specify a bool for that value packer returns an error that only "UTC" or "local" are valid values.

Here is the source that shows the same: https://github.com/hashicorp/packer-plugin-virtualbox/blob/0dbf4466965fc8b4f866de32f14490185d325872/builder/virtualbox/iso/builder.go#L244-L250
