### PR TITLE
bump go 1.18 to 1.19

### DIFF
--- a/builder/virtualbox/common/step_attach_floppy.go
+++ b/builder/virtualbox/common/step_attach_floppy.go
@@ -19,9 +19,10 @@ import (
 // This step attaches the ISO to the virtual machine.
 //
 // Uses:
-//   driver Driver
-//   ui packersdk.Ui
-//   vmName string
+//
+//	driver Driver
+//	ui packersdk.Ui
+//	vmName string
 //
 // Produces:
 type StepAttachFloppy struct {

--- a/builder/virtualbox/common/step_configure_vrdp.go
+++ b/builder/virtualbox/common/step_configure_vrdp.go
@@ -17,9 +17,10 @@ import (
 // on the guest machine.
 //
 // Uses:
-//   driver Driver
-//   ui packersdk.Ui
-//   vmName string
+//
+//	driver Driver
+//	ui packersdk.Ui
+//	vmName string
 //
 // Produces:
 // vrdp_port unit - The port that VRDP is configured to listen on.

--- a/builder/virtualbox/common/step_download_guest_additions.go
+++ b/builder/virtualbox/common/step_download_guest_additions.go
@@ -32,7 +32,8 @@ type guestAdditionsUrlTemplate struct {
 // can be useful for various provisioning reasons.
 //
 // Produces:
-//   guest_additions_path string - Path to the guest additions.
+//
+//	guest_additions_path string - Path to the guest additions.
 type StepDownloadGuestAdditions struct {
 	GuestAdditionsMode   string
 	GuestAdditionsURL    string

--- a/builder/virtualbox/common/step_export.go
+++ b/builder/virtualbox/common/step_export.go
@@ -18,7 +18,8 @@ import (
 // Uses:
 //
 // Produces:
-//   exportPath string - The path to the resulting export.
+//
+//	exportPath string - The path to the resulting export.
 type StepExport struct {
 	Format         string
 	OutputDir      string

--- a/builder/virtualbox/common/step_port_forwarding.go
+++ b/builder/virtualbox/common/step_port_forwarding.go
@@ -19,9 +19,10 @@ import (
 // on the guest machine.
 //
 // Uses:
-//   driver Driver
-//   ui packersdk.Ui
-//   vmName string
+//
+//	driver Driver
+//	ui packersdk.Ui
+//	vmName string
 //
 // Produces:
 type StepPortForwarding struct {

--- a/builder/virtualbox/common/step_remove_devices.go
+++ b/builder/virtualbox/common/step_remove_devices.go
@@ -18,9 +18,10 @@ import (
 // machine that we may have added.
 //
 // Uses:
-//   driver Driver
-//   ui packersdk.Ui
-//   vmName string
+//
+//	driver Driver
+//	ui packersdk.Ui
+//	vmName string
 //
 // Produces:
 type StepRemoveDevices struct {

--- a/builder/virtualbox/common/step_run.go
+++ b/builder/virtualbox/common/step_run.go
@@ -14,9 +14,10 @@ import (
 // This step starts the virtual machine.
 //
 // Uses:
-//   driver Driver
-//   ui packersdk.Ui
-//   vmName string
+//
+//	driver Driver
+//	ui packersdk.Ui
+//	vmName string
 //
 // Produces:
 type StepRun struct {

--- a/builder/virtualbox/common/step_shutdown.go
+++ b/builder/virtualbox/common/step_shutdown.go
@@ -18,13 +18,15 @@ import (
 // but ultimately forcefully shuts it down if that fails.
 //
 // Uses:
-//   communicator packersdk.Communicator
-//   driver Driver
-//   ui     packersdk.Ui
-//   vmName string
+//
+//	communicator packersdk.Communicator
+//	driver Driver
+//	ui     packersdk.Ui
+//	vmName string
 //
 // Produces:
-//   <nothing>
+//
+//	<nothing>
 type StepShutdown struct {
 	Command         string
 	Timeout         time.Duration

--- a/builder/virtualbox/common/step_type_boot_command.go
+++ b/builder/virtualbox/common/step_type_boot_command.go
@@ -18,7 +18,8 @@ import (
 const KeyLeftShift uint32 = 0xFFE1
 
 // TODO: Should this be made available for other builders?
-//  It is copy pasted in the VMWare builder as well.
+//
+//	It is copy pasted in the VMWare builder as well.
 type bootCommandTemplateData struct {
 	// HTTPIP is the HTTP server's IP address.
 	HTTPIP string

--- a/builder/virtualbox/common/step_vboxmanage.go
+++ b/builder/virtualbox/common/step_vboxmanage.go
@@ -27,9 +27,10 @@ type commandTemplate struct {
 // template.
 //
 // Uses:
-//   driver Driver
-//   ui packersdk.Ui
-//   vmName string
+//
+//	driver Driver
+//	ui packersdk.Ui
+//	vmName string
 //
 // Produces:
 type StepVBoxManage struct {

--- a/builder/virtualbox/common/vboxmanage_config.go
+++ b/builder/virtualbox/common/vboxmanage_config.go
@@ -9,11 +9,11 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
-//In order to perform extra customization of the virtual machine, a template can
-//define extra calls to `VBoxManage` to perform.
-//[VBoxManage](https://www.virtualbox.org/manual/ch09.html) is the command-line
-//interface to VirtualBox where you can completely control VirtualBox. It can be
-//used to do things such as set RAM, CPUs, etc.
+// In order to perform extra customization of the virtual machine, a template can
+// define extra calls to `VBoxManage` to perform.
+// [VBoxManage](https://www.virtualbox.org/manual/ch09.html) is the command-line
+// interface to VirtualBox where you can completely control VirtualBox. It can be
+// used to do things such as set RAM, CPUs, etc.
 type VBoxManageConfig struct {
 	// Custom `VBoxManage` commands to execute in order to further customize
 	// the virtual machine being created. The example shown below sets the memory and number of CPUs

--- a/builder/virtualbox/iso/step_create_vm.go
+++ b/builder/virtualbox/iso/step_create_vm.go
@@ -17,7 +17,8 @@ import (
 // This step creates the actual virtual machine.
 //
 // Produces:
-//   vmName string - The name of the VM
+//
+//	vmName string - The name of the VM
 type stepCreateVM struct {
 	vmName string
 }

--- a/builder/virtualbox/ovf/config_test.go
+++ b/builder/virtualbox/ovf/config_test.go
@@ -115,6 +115,7 @@ func TestNewConfig_shutdown_timeout(t *testing.T) {
 }
 
 // TestChecksumFileNameMixedCaseBug reproduces Github issue #9049:
+//
 //	https://github.com/hashicorp/packer-plugin-virtualbox/issues/9049
 func TestChecksumFileNameMixedCaseBug(t *testing.T) {
 	tt := []struct {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/packer-plugin-virtualbox
 
-go 1.18
+go 1.19
 
 require (
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3


### PR DESCRIPTION
- github: remove test-plugin-example workflow
- go.mod: bump go version from 1.18 to 1.19
