### PR TITLE
web-docs: change snapshot builder name to VM

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -16,7 +16,7 @@ integration {
   }
   component {
     type = "builder"
-    name = "VirtualBox Snapshot"
+    name = "VirtualBox VM"
     slug = "vm"
   }
 }


### PR DESCRIPTION
The slug of the builder being `virtualbox-vm`, and the current documentation naming it as "VM", it feels counter-intuitive to rename it to something else while we transition to the new documentation system, so we go back to the old naming scheme for the builder.
