### PR TITLE
builder/iso: Use `--audio-driver` instead of the deprecated `--audio` parameter

### DIFF
--- a/builder/virtualbox/iso/step_create_vm.go
+++ b/builder/virtualbox/iso/step_create_vm.go
@@ -47,10 +47,10 @@ func (s *stepCreateVM) Run(ctx context.Context, state multistep.StateBag) multis
 	commands = append(commands, []string{"modifyvm", name, "--usb", map[bool]string{true: "on", false: "off"}[config.HWConfig.USB]})
 
 	if strings.ToLower(config.HWConfig.Sound) == "none" {
-		commands = append(commands, []string{"modifyvm", name, "--audio", config.HWConfig.Sound,
+		commands = append(commands, []string{"modifyvm", name, "--audio-driver", config.HWConfig.Sound,
 			"--audiocontroller", config.AudioController})
 	} else {
-		commands = append(commands, []string{"modifyvm", name, "--audio", config.HWConfig.Sound, "--audioin", "on", "--audioout", "on",
+		commands = append(commands, []string{"modifyvm", name, "--audio-driver", config.HWConfig.Sound, "--audioin", "on", "--audioout", "on",
 			"--audiocontroller", config.AudioController})
 	}
 


### PR DESCRIPTION
--audio is deprecated, use --audio-driver instead.
