### PR TITLE
Support .vhd file

### DIFF
--- a/builder/virtualbox/iso/step_create_disk.go
+++ b/builder/virtualbox/iso/step_create_disk.go
@@ -6,11 +6,10 @@ package iso
 import (
 	"context"
 	"fmt"
-
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	vboxcommon "github.com/hashicorp/packer-plugin-virtualbox/builder/virtualbox/common"
-
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -25,45 +24,6 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	driver := state.Get("driver").(vboxcommon.Driver)
 	ui := state.Get("ui").(packersdk.Ui)
 	vmName := state.Get("vmName").(string)
-	format := "VDI"
-
-	// The main disk and additional disks
-	diskFullPaths := []string{}
-	diskSizes := []uint{config.DiskSize}
-	if len(config.AdditionalDiskSize) == 0 {
-		// If there are no additional disks, use disk naming as before
-		diskFullPaths = append(diskFullPaths, filepath.Join(config.OutputDir, fmt.Sprintf("%s.%s", config.VMName, strings.ToLower(format))))
-	} else {
-		// If there are additional disks, use consistent naming with numbers
-		diskFullPaths = append(diskFullPaths, filepath.Join(config.OutputDir, fmt.Sprintf("%s-0.%s", config.VMName, strings.ToLower(format))))
-
-		for i, diskSize := range config.AdditionalDiskSize {
-			path := filepath.Join(config.OutputDir, fmt.Sprintf("%s-%d.%s", config.VMName, i+1, strings.ToLower(format)))
-			diskFullPaths = append(diskFullPaths, path)
-			diskSizes = append(diskSizes, diskSize)
-		}
-	}
-
-	// Create all required disks
-	for i := range diskFullPaths {
-		ui.Say(fmt.Sprintf("Creating hard drive %s with size %d MiB...", diskFullPaths[i], diskSizes[i]))
-
-		command := []string{
-			"createhd",
-			"--filename", diskFullPaths[i],
-			"--size", strconv.FormatUint(uint64(diskSizes[i]), 10),
-			"--format", format,
-			"--variant", "Standard",
-		}
-
-		err := driver.VBoxManage(command...)
-		if err != nil {
-			err := fmt.Errorf("Error creating hard drive: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
-	}
 
 	// Add the IDE controller so we can later attach the disk.
 	// When the hard disk controller is not IDE, this device is still used
@@ -116,45 +76,88 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 		}
 	}
 
-	// Attach the disk to the controller
-	controllerName := "IDE Controller"
-	if config.HardDriveInterface == "sata" {
-		controllerName = "SATA Controller"
-	} else if config.HardDriveInterface == "scsi" {
-		controllerName = "SCSI Controller"
-	} else if config.HardDriveInterface == "virtio" {
-		controllerName = "VirtIO Controller"
-	} else if config.HardDriveInterface == "pcie" {
-		controllerName = "NVMe Controller"
-	}
+	format := "VDI"
 
-	nonrotational := "off"
-	if config.HardDriveNonrotational {
-		nonrotational = "on"
-	}
+	// The main disk and additional disks
+	diskFullPaths := []string{}
+	diskSizes := []uint{config.DiskSize}
+	if len(config.AdditionalDiskSize) == 0 {
+		// If there are no additional disks, use disk naming as before
+		diskFullPaths = append(diskFullPaths, filepath.Join(config.OutputDir, fmt.Sprintf("%s.%s", config.VMName, strings.ToLower(format))))
+	} else {
+		// If there are additional disks, use consistent naming with numbers
+		diskFullPaths = append(diskFullPaths, filepath.Join(config.OutputDir, fmt.Sprintf("%s-0.%s", config.VMName, strings.ToLower(format))))
 
-	discard := "off"
-	if config.HardDriveDiscard {
-		discard = "on"
-	}
-
-	for i := range diskFullPaths {
-		command := []string{
-			"storageattach", vmName,
-			"--storagectl", controllerName,
-			"--port", strconv.FormatUint(uint64(i), 10),
-			"--device", "0",
-			"--type", "hdd",
-			"--medium", diskFullPaths[i],
-			"--nonrotational", nonrotational,
-			"--discard", discard,
+		for i, diskSize := range config.AdditionalDiskSize {
+			diskPath := filepath.Join(config.OutputDir, fmt.Sprintf("%s-%d.%s", config.VMName, i+1, strings.ToLower(format)))
+			diskFullPaths = append(diskFullPaths, diskPath)
+			diskSizes = append(diskSizes, diskSize)
 		}
-		if err := driver.VBoxManage(command...); err != nil {
-			err := fmt.Errorf("Error attaching hard drive: %s", err)
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
+	}
+
+	if path.Ext(state.Get("iso_path").(string)) != ".vhd" {
+		// Create all required disks
+		for i := range diskFullPaths {
+			ui.Say(fmt.Sprintf("Creating hard drive %s with size %d MiB...", diskFullPaths[i], diskSizes[i]))
+
+			command := []string{
+				"createhd",
+				"--filename", diskFullPaths[i],
+				"--size", strconv.FormatUint(uint64(diskSizes[i]), 10),
+				"--format", format,
+				"--variant", "Standard",
+			}
+
+			err := driver.VBoxManage(command...)
+			if err != nil {
+				err := fmt.Errorf("Error creating hard drive: %s", err)
+				state.Put("error", err)
+				ui.Error(err.Error())
+				return multistep.ActionHalt
+			}
 		}
+
+		// Attach the disk to the controller
+		controllerName := "IDE Controller"
+		if config.HardDriveInterface == "sata" {
+			controllerName = "SATA Controller"
+		} else if config.HardDriveInterface == "scsi" {
+			controllerName = "SCSI Controller"
+		} else if config.HardDriveInterface == "virtio" {
+			controllerName = "VirtIO Controller"
+		} else if config.HardDriveInterface == "pcie" {
+			controllerName = "NVMe Controller"
+		}
+
+		nonrotational := "off"
+		if config.HardDriveNonrotational {
+			nonrotational = "on"
+		}
+
+		discard := "off"
+		if config.HardDriveDiscard {
+			discard = "on"
+		}
+
+		for i := range diskFullPaths {
+			command := []string{
+				"storageattach", vmName,
+				"--storagectl", controllerName,
+				"--port", strconv.FormatUint(uint64(i), 10),
+				"--device", "0",
+				"--type", "hdd",
+				"--medium", diskFullPaths[i],
+				"--nonrotational", nonrotational,
+				"--discard", discard,
+			}
+			if err := driver.VBoxManage(command...); err != nil {
+				err := fmt.Errorf("Error attaching hard drive: %s", err)
+				state.Put("error", err)
+				ui.Error(err.Error())
+				return multistep.ActionHalt
+			}
+		}
+
 	}
 
 	return multistep.ActionContinue


### PR DESCRIPTION
This PR adds support for `.vhd` files.

Before this PR, when using a `.vhd` as the `iso_url` (as stated possible in the [documentation](https://developer.hashicorp.com/packer/integrations/hashicorp/virtualbox/latest/components/builder/iso#required:)), VirtualBox returns the error `Error attaching ISO: VBoxManage error: VBoxManage.exe: error: The medium '<path/to/vhd>' can't be used as the requested device type (DVD, detected HDD)`.

This solves the issue by checking the extension of the file and, if it is `.vhd`, by changing the disk type from `dvddrive` to `hdd` in the VirtualBox' VM creation command.
If using a `hdd` type disk, it will not be unmounted before export.
It also removes the creation of a `.vdi` disk if using a `.vhd`.

However, by using directly the `.vhd` file, it is modified and won't remain the same after running packer.
An improvement would be to clone the `.vhd` file to the temp directory, as (for example) the Hyper-V plugin do.

This closes #123
