### PR TITLE
fix doc links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,19 +30,19 @@ machines, depending on the strategy you want to use to build the image.
 The following VirtualBox builders are supported:
 
 #### Builders
-- [virtualbox-iso](/packer/integrations/hashicorp/virtualbox/latest/components/builder/iso) - Starts from an ISO
+- [virtualbox-iso](../.web-docs/components/builder/iso/README.md) - Starts from an ISO
   file, creates a brand new VirtualBox VM, installs an OS, provisions
   software within the OS, then exports that machine to create an image. This
   is best for people who want to start from scratch.
 
-- [virtualbox-ovf](/packer/integrations/hashicorp/virtualbox/latest/components/builder/ovf) - This builder imports
+- [virtualbox-ovf](../.web-docs/components/builder/ovf/README.md) - This builder imports
   an existing OVF/OVA file, runs provisioners on top of that VM, and exports
   that machine to create an image. This is best if you have an existing
   VirtualBox VM export you want to use as the source. As an additional
   benefit, you can feed the artifact of this builder back into itself to
   iterate on a machine.
 
-- [virtualbox-vm](/packer/integrations/hashicorp/virtualbox/latest/components/builder/vm) - This builder uses an
+- [virtualbox-vm](../.web-docs/components/builder/vm/README.md) - This builder uses an
   existing VM to run defined provisioners on top of that VM, and optionally
   creates a snapshot to save the changes applied from the provisioners. In
   addition the builder is able to export that machine to create an image. The


### PR DESCRIPTION

These links are broken, so this fixes them.

Reproduction:
* go to https://github.com/hashicorp/packer-plugin-virtualbox/tree/main/docs
* click the `virtualbox-iso` link
* see this:
* ![image](https://github.com/hashicorp/packer-plugin-virtualbox/assets/5614134/73cc7c1a-9d25-42b6-a295-ba7c40c4fca1)

Verify fix:
* go to my fork's branch: https://github.com/jcrben/packer-plugin-virtualbox/tree/fix-doc-links/docs
* click the same link
* it works: https://github.com/jcrben/packer-plugin-virtualbox/tree/fix-doc-links/docs