### PR TITLE
Ability to port forward ssh for all interfaces

### DIFF
--- a/builder/virtualbox/common/comm_config.go
+++ b/builder/virtualbox/common/comm_config.go
@@ -26,6 +26,9 @@ type CommConfig struct {
 	// does not setup forwarded port mapping for communicator (SSH or WinRM) requests and uses ssh_port or winrm_port
 	// on the host to communicate to the virtual machine.
 	SkipNatMapping bool `mapstructure:"skip_nat_mapping" required:"false"`
+	// Defaults to false. When enabled, the ssh port forwarding will be set to listen on 0.0.0.0
+	// as opposed to 127.0.0.1
+	SSHListenOnAllInterfaces bool `mapstructure:"ssh_listen_on_all_interfaces" required:"false"`
 
 	// These are deprecated, but we keep them around for backwards compatibility
 	// TODO: remove later

--- a/builder/virtualbox/common/step_port_forwarding.go
+++ b/builder/virtualbox/common/step_port_forwarding.go
@@ -28,10 +28,11 @@ import (
 //
 // Produces:
 type StepPortForwarding struct {
-	CommConfig     *communicator.Config
-	HostPortMin    int
-	HostPortMax    int
-	SkipNatMapping bool
+	CommConfig               *communicator.Config
+	HostPortMin              int
+	HostPortMax              int
+	SkipNatMapping           bool
+	SSHListenOnAllInterfaces bool
 
 	l *net.Listener
 }
@@ -133,10 +134,16 @@ func (s *StepPortForwarding) Run(ctx context.Context, state multistep.StateBag) 
 
 		// Create a forwarded port mapping to the VM
 		ui.Say(fmt.Sprintf("Creating forwarded port mapping for communicator (SSH, WinRM, etc) (host port %d)", commHostPort))
+
+		bindingAddress := "127.0.0.1"
+		if s.SSHListenOnAllInterfaces {
+			bindingAddress = "0.0.0.0"
+		}
+
 		command = []string{
 			"modifyvm", vmName,
 			"--natpf1",
-			fmt.Sprintf("packercomm,tcp,127.0.0.1,%d,,%d", commHostPort, guestPort),
+			fmt.Sprintf("packercomm,tcp,%s,%d,,%d", bindingAddress, commHostPort, guestPort),
 		}
 		retried := false
 	retry:

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -432,10 +432,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		new(vboxcommon.StepAttachFloppy),
 		&vboxcommon.StepPortForwarding{
-			CommConfig:     &b.config.CommConfig.Comm,
-			HostPortMin:    b.config.HostPortMin,
-			HostPortMax:    b.config.HostPortMax,
-			SkipNatMapping: b.config.SkipNatMapping,
+			CommConfig:               &b.config.CommConfig.Comm,
+			HostPortMin:              b.config.HostPortMin,
+			HostPortMax:              b.config.HostPortMax,
+			SkipNatMapping:           b.config.SkipNatMapping,
+			SSHListenOnAllInterfaces: b.config.SSHListenOnAllInterfaces,
 		},
 		&vboxcommon.StepVBoxManage{
 			Commands: b.config.VBoxManage,

--- a/builder/virtualbox/iso/builder.hcl2spec.go
+++ b/builder/virtualbox/iso/builder.hcl2spec.go
@@ -104,6 +104,7 @@ type FlatConfig struct {
 	HostPortMin               *int              `mapstructure:"host_port_min" required:"false" cty:"host_port_min" hcl:"host_port_min"`
 	HostPortMax               *int              `mapstructure:"host_port_max" required:"false" cty:"host_port_max" hcl:"host_port_max"`
 	SkipNatMapping            *bool             `mapstructure:"skip_nat_mapping" required:"false" cty:"skip_nat_mapping" hcl:"skip_nat_mapping"`
+	SSHListenOnAllInterfaces  *bool             `mapstructure:"ssh_listen_on_all_interfaces" required:"false" cty:"ssh_listen_on_all_interfaces" hcl:"ssh_listen_on_all_interfaces"`
 	SSHHostPortMin            *int              `mapstructure:"ssh_host_port_min" required:"false" cty:"ssh_host_port_min" hcl:"ssh_host_port_min"`
 	SSHHostPortMax            *int              `mapstructure:"ssh_host_port_max" cty:"ssh_host_port_max" hcl:"ssh_host_port_max"`
 	SSHSkipNatMapping         *bool             `mapstructure:"ssh_skip_nat_mapping" required:"false" cty:"ssh_skip_nat_mapping" hcl:"ssh_skip_nat_mapping"`
@@ -250,6 +251,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"host_port_min":                &hcldec.AttrSpec{Name: "host_port_min", Type: cty.Number, Required: false},
 		"host_port_max":                &hcldec.AttrSpec{Name: "host_port_max", Type: cty.Number, Required: false},
 		"skip_nat_mapping":             &hcldec.AttrSpec{Name: "skip_nat_mapping", Type: cty.Bool, Required: false},
+		"ssh_listen_on_all_interfaces": &hcldec.AttrSpec{Name: "ssh_listen_on_all_interfaces", Type: cty.Bool, Required: false},
 		"ssh_host_port_min":            &hcldec.AttrSpec{Name: "ssh_host_port_min", Type: cty.Number, Required: false},
 		"ssh_host_port_max":            &hcldec.AttrSpec{Name: "ssh_host_port_max", Type: cty.Number, Required: false},
 		"ssh_skip_nat_mapping":         &hcldec.AttrSpec{Name: "ssh_skip_nat_mapping", Type: cty.Bool, Required: false},

--- a/builder/virtualbox/iso/builder.hcl2spec.go
+++ b/builder/virtualbox/iso/builder.hcl2spec.go
@@ -24,6 +24,7 @@ type FlatConfig struct {
 	HTTPPortMax               *int              `mapstructure:"http_port_max" cty:"http_port_max" hcl:"http_port_max"`
 	HTTPAddress               *string           `mapstructure:"http_bind_address" cty:"http_bind_address" hcl:"http_bind_address"`
 	HTTPInterface             *string           `mapstructure:"http_interface" undocumented:"true" cty:"http_interface" hcl:"http_interface"`
+	HTTPOnlyIPv4              *bool             `mapstructure:"http_only_ipv4" cty:"http_only_ipv4" hcl:"http_only_ipv4"`
 	ISOChecksum               *string           `mapstructure:"iso_checksum" required:"true" cty:"iso_checksum" hcl:"iso_checksum"`
 	RawSingleISOUrl           *string           `mapstructure:"iso_url" required:"true" cty:"iso_url" hcl:"iso_url"`
 	ISOUrls                   []string          `mapstructure:"iso_urls" cty:"iso_urls" hcl:"iso_urls"`
@@ -171,6 +172,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"http_port_max":                &hcldec.AttrSpec{Name: "http_port_max", Type: cty.Number, Required: false},
 		"http_bind_address":            &hcldec.AttrSpec{Name: "http_bind_address", Type: cty.String, Required: false},
 		"http_interface":               &hcldec.AttrSpec{Name: "http_interface", Type: cty.String, Required: false},
+		"http_only_ipv4":               &hcldec.AttrSpec{Name: "http_only_ipv4", Type: cty.Bool, Required: false},
 		"iso_checksum":                 &hcldec.AttrSpec{Name: "iso_checksum", Type: cty.String, Required: false},
 		"iso_url":                      &hcldec.AttrSpec{Name: "iso_url", Type: cty.String, Required: false},
 		"iso_urls":                     &hcldec.AttrSpec{Name: "iso_urls", Type: cty.List(cty.String), Required: false},

--- a/builder/virtualbox/ovf/builder.go
+++ b/builder/virtualbox/ovf/builder.go
@@ -107,10 +107,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		new(vboxcommon.StepAttachFloppy),
 		&vboxcommon.StepPortForwarding{
-			CommConfig:     &b.config.CommConfig.Comm,
-			HostPortMin:    b.config.HostPortMin,
-			HostPortMax:    b.config.HostPortMax,
-			SkipNatMapping: b.config.SkipNatMapping,
+			CommConfig:               &b.config.CommConfig.Comm,
+			HostPortMin:              b.config.HostPortMin,
+			HostPortMax:              b.config.HostPortMax,
+			SkipNatMapping:           b.config.SkipNatMapping,
+			SSHListenOnAllInterfaces: b.config.SSHListenOnAllInterfaces,
 		},
 		&vboxcommon.StepVBoxManage{
 			Commands: b.config.VBoxManage,

--- a/builder/virtualbox/ovf/config.hcl2spec.go
+++ b/builder/virtualbox/ovf/config.hcl2spec.go
@@ -94,6 +94,7 @@ type FlatConfig struct {
 	HostPortMin               *int              `mapstructure:"host_port_min" required:"false" cty:"host_port_min" hcl:"host_port_min"`
 	HostPortMax               *int              `mapstructure:"host_port_max" required:"false" cty:"host_port_max" hcl:"host_port_max"`
 	SkipNatMapping            *bool             `mapstructure:"skip_nat_mapping" required:"false" cty:"skip_nat_mapping" hcl:"skip_nat_mapping"`
+	SSHListenOnAllInterfaces  *bool             `mapstructure:"ssh_listen_on_all_interfaces" required:"false" cty:"ssh_listen_on_all_interfaces" hcl:"ssh_listen_on_all_interfaces"`
 	SSHHostPortMin            *int              `mapstructure:"ssh_host_port_min" required:"false" cty:"ssh_host_port_min" hcl:"ssh_host_port_min"`
 	SSHHostPortMax            *int              `mapstructure:"ssh_host_port_max" cty:"ssh_host_port_max" hcl:"ssh_host_port_max"`
 	SSHSkipNatMapping         *bool             `mapstructure:"ssh_skip_nat_mapping" required:"false" cty:"ssh_skip_nat_mapping" hcl:"ssh_skip_nat_mapping"`
@@ -216,6 +217,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"host_port_min":                &hcldec.AttrSpec{Name: "host_port_min", Type: cty.Number, Required: false},
 		"host_port_max":                &hcldec.AttrSpec{Name: "host_port_max", Type: cty.Number, Required: false},
 		"skip_nat_mapping":             &hcldec.AttrSpec{Name: "skip_nat_mapping", Type: cty.Bool, Required: false},
+		"ssh_listen_on_all_interfaces": &hcldec.AttrSpec{Name: "ssh_listen_on_all_interfaces", Type: cty.Bool, Required: false},
 		"ssh_host_port_min":            &hcldec.AttrSpec{Name: "ssh_host_port_min", Type: cty.Number, Required: false},
 		"ssh_host_port_max":            &hcldec.AttrSpec{Name: "ssh_host_port_max", Type: cty.Number, Required: false},
 		"ssh_skip_nat_mapping":         &hcldec.AttrSpec{Name: "ssh_skip_nat_mapping", Type: cty.Bool, Required: false},

--- a/builder/virtualbox/ovf/config.hcl2spec.go
+++ b/builder/virtualbox/ovf/config.hcl2spec.go
@@ -24,6 +24,7 @@ type FlatConfig struct {
 	HTTPPortMax               *int              `mapstructure:"http_port_max" cty:"http_port_max" hcl:"http_port_max"`
 	HTTPAddress               *string           `mapstructure:"http_bind_address" cty:"http_bind_address" hcl:"http_bind_address"`
 	HTTPInterface             *string           `mapstructure:"http_interface" undocumented:"true" cty:"http_interface" hcl:"http_interface"`
+	HTTPOnlyIPv4              *bool             `mapstructure:"http_only_ipv4" cty:"http_only_ipv4" hcl:"http_only_ipv4"`
 	FloppyFiles               []string          `mapstructure:"floppy_files" cty:"floppy_files" hcl:"floppy_files"`
 	FloppyDirectories         []string          `mapstructure:"floppy_dirs" cty:"floppy_dirs" hcl:"floppy_dirs"`
 	FloppyContent             map[string]string `mapstructure:"floppy_content" cty:"floppy_content" hcl:"floppy_content"`
@@ -147,6 +148,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"http_port_max":                &hcldec.AttrSpec{Name: "http_port_max", Type: cty.Number, Required: false},
 		"http_bind_address":            &hcldec.AttrSpec{Name: "http_bind_address", Type: cty.String, Required: false},
 		"http_interface":               &hcldec.AttrSpec{Name: "http_interface", Type: cty.String, Required: false},
+		"http_only_ipv4":               &hcldec.AttrSpec{Name: "http_only_ipv4", Type: cty.Bool, Required: false},
 		"floppy_files":                 &hcldec.AttrSpec{Name: "floppy_files", Type: cty.List(cty.String), Required: false},
 		"floppy_dirs":                  &hcldec.AttrSpec{Name: "floppy_dirs", Type: cty.List(cty.String), Required: false},
 		"floppy_content":               &hcldec.AttrSpec{Name: "floppy_content", Type: cty.Map(cty.String), Required: false},

--- a/builder/virtualbox/vm/builder.go
+++ b/builder/virtualbox/vm/builder.go
@@ -91,10 +91,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		new(vboxcommon.StepAttachFloppy),
 		&vboxcommon.StepPortForwarding{
-			CommConfig:     &b.config.CommConfig.Comm,
-			HostPortMin:    b.config.HostPortMin,
-			HostPortMax:    b.config.HostPortMax,
-			SkipNatMapping: b.config.SkipNatMapping,
+			CommConfig:               &b.config.CommConfig.Comm,
+			HostPortMin:              b.config.HostPortMin,
+			HostPortMax:              b.config.HostPortMax,
+			SkipNatMapping:           b.config.SkipNatMapping,
+			SSHListenOnAllInterfaces: b.config.SSHListenOnAllInterfaces,
 		},
 		&vboxcommon.StepVBoxManage{
 			Commands: b.config.VBoxManage,

--- a/builder/virtualbox/vm/config.hcl2spec.go
+++ b/builder/virtualbox/vm/config.hcl2spec.go
@@ -94,6 +94,7 @@ type FlatConfig struct {
 	HostPortMin               *int              `mapstructure:"host_port_min" required:"false" cty:"host_port_min" hcl:"host_port_min"`
 	HostPortMax               *int              `mapstructure:"host_port_max" required:"false" cty:"host_port_max" hcl:"host_port_max"`
 	SkipNatMapping            *bool             `mapstructure:"skip_nat_mapping" required:"false" cty:"skip_nat_mapping" hcl:"skip_nat_mapping"`
+	SSHListenOnAllInterfaces  *bool             `mapstructure:"ssh_listen_on_all_interfaces" required:"false" cty:"ssh_listen_on_all_interfaces" hcl:"ssh_listen_on_all_interfaces"`
 	SSHHostPortMin            *int              `mapstructure:"ssh_host_port_min" required:"false" cty:"ssh_host_port_min" hcl:"ssh_host_port_min"`
 	SSHHostPortMax            *int              `mapstructure:"ssh_host_port_max" cty:"ssh_host_port_max" hcl:"ssh_host_port_max"`
 	SSHSkipNatMapping         *bool             `mapstructure:"ssh_skip_nat_mapping" required:"false" cty:"ssh_skip_nat_mapping" hcl:"ssh_skip_nat_mapping"`
@@ -214,6 +215,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"host_port_min":                &hcldec.AttrSpec{Name: "host_port_min", Type: cty.Number, Required: false},
 		"host_port_max":                &hcldec.AttrSpec{Name: "host_port_max", Type: cty.Number, Required: false},
 		"skip_nat_mapping":             &hcldec.AttrSpec{Name: "skip_nat_mapping", Type: cty.Bool, Required: false},
+		"ssh_listen_on_all_interfaces": &hcldec.AttrSpec{Name: "ssh_listen_on_all_interfaces", Type: cty.Bool, Required: false},
 		"ssh_host_port_min":            &hcldec.AttrSpec{Name: "ssh_host_port_min", Type: cty.Number, Required: false},
 		"ssh_host_port_max":            &hcldec.AttrSpec{Name: "ssh_host_port_max", Type: cty.Number, Required: false},
 		"ssh_skip_nat_mapping":         &hcldec.AttrSpec{Name: "ssh_skip_nat_mapping", Type: cty.Bool, Required: false},

--- a/builder/virtualbox/vm/config.hcl2spec.go
+++ b/builder/virtualbox/vm/config.hcl2spec.go
@@ -24,6 +24,7 @@ type FlatConfig struct {
 	HTTPPortMax               *int              `mapstructure:"http_port_max" cty:"http_port_max" hcl:"http_port_max"`
 	HTTPAddress               *string           `mapstructure:"http_bind_address" cty:"http_bind_address" hcl:"http_bind_address"`
 	HTTPInterface             *string           `mapstructure:"http_interface" undocumented:"true" cty:"http_interface" hcl:"http_interface"`
+	HTTPOnlyIPv4              *bool             `mapstructure:"http_only_ipv4" cty:"http_only_ipv4" hcl:"http_only_ipv4"`
 	FloppyFiles               []string          `mapstructure:"floppy_files" cty:"floppy_files" hcl:"floppy_files"`
 	FloppyDirectories         []string          `mapstructure:"floppy_dirs" cty:"floppy_dirs" hcl:"floppy_dirs"`
 	FloppyContent             map[string]string `mapstructure:"floppy_content" cty:"floppy_content" hcl:"floppy_content"`
@@ -145,6 +146,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"http_port_max":                &hcldec.AttrSpec{Name: "http_port_max", Type: cty.Number, Required: false},
 		"http_bind_address":            &hcldec.AttrSpec{Name: "http_bind_address", Type: cty.String, Required: false},
 		"http_interface":               &hcldec.AttrSpec{Name: "http_interface", Type: cty.String, Required: false},
+		"http_only_ipv4":               &hcldec.AttrSpec{Name: "http_only_ipv4", Type: cty.Bool, Required: false},
 		"floppy_files":                 &hcldec.AttrSpec{Name: "floppy_files", Type: cty.List(cty.String), Required: false},
 		"floppy_dirs":                  &hcldec.AttrSpec{Name: "floppy_dirs", Type: cty.List(cty.String), Required: false},
 		"floppy_content":               &hcldec.AttrSpec{Name: "floppy_content", Type: cty.Map(cty.String), Required: false},

--- a/docs-partials/builder/virtualbox/common/CommConfig-not-required.mdx
+++ b/docs-partials/builder/virtualbox/common/CommConfig-not-required.mdx
@@ -12,4 +12,7 @@
   does not setup forwarded port mapping for communicator (SSH or WinRM) requests and uses ssh_port or winrm_port
   on the host to communicate to the virtual machine.
 
+- `ssh_listen_on_all_interfaces` (bool) - Defaults to false. When enabled, the ssh port forwarding will be set to listen on 0.0.0.0
+  as opposed to 127.0.0.1
+
 <!-- End of code generated from the comments of the CommConfig struct in builder/virtualbox/common/comm_config.go; -->


### PR DESCRIPTION
## Motivation

While trying to run the virtual-box-iso builder on a WSL2 environment, I had issues getting the WSL2 to connect to the VirtualBox running on the Windows host through SSH. 

This is because a connection coming from WSL is not considered a local connection (at least when using the default `NAT` networkingMode on WSL) and the virtual box is hard coded to port forward request coming on `127.0.0.1`.

## Changes

Added the property `ssh_listen_on_all_interfaces` which makes it possible for clients to change the port forwarding rule to forward requests coming from all available interfaces.

## Dependency

This pull-request depends on https://github.com/hashicorp/packer-plugin-sdk/pull/257 since it was used to generate the documentation for the `http_only_ipv4` property and to test the overall changes.