### PR TITLE
Cut 1.1.0 release

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -7,7 +7,7 @@ import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.0.5"
+	Version = "1.1.0"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this

--- a/version/version.go
+++ b/version/version.go
@@ -7,12 +7,12 @@ import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.1.0"
+	Version = "1.1.1"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
 	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = ""
+	VersionPrerelease = "dev"
 
 	// PluginVersion is used by the plugin set to allow Packer to recognize
 	// what version this plugin is.


### PR DESCRIPTION
- **Cut release 1.1.0**
- **Prepare for 1.1.1 development**

This minor release includes changes that are specific to Virtualbox 7.0 for fixing
networking issues related to the disabled access to the host gateway address.
