### PR TITLE
Use --audio-enabled to disable audio if driver is none

### DIFF
--- a/builder/virtualbox/iso/step_create_vm.go
+++ b/builder/virtualbox/iso/step_create_vm.go
@@ -47,9 +47,9 @@ func (s *stepCreateVM) Run(ctx context.Context, state multistep.StateBag) multis
 	commands = append(commands, []string{"modifyvm", name, "--usb", map[bool]string{true: "on", false: "off"}[config.HWConfig.USB]})
 
 	if strings.ToLower(config.HWConfig.Sound) == "none" {
-		commands = append(commands, []string{"modifyvm", name, "--audio-driver", config.HWConfig.Sound,
-			"--audiocontroller", config.AudioController})
+		commands = append(commands, []string{"modifyvm", name, "--audio-enabled", "off"})
 	} else {
+		commands = append(commands, []string{"modifyvm", name, "--audio-enabled", "on"})
 		commands = append(commands, []string{"modifyvm", name, "--audio-driver", config.HWConfig.Sound, "--audioin", "on", "--audioout", "on",
 			"--audiocontroller", config.AudioController})
 	}


### PR DESCRIPTION
Possibility to disable audio when the driver is set to none

Closes #137 

