### PR TITLE
Add support for toggling audio driver flag based on VBox version

### DIFF
--- a/builder/virtualbox/iso/step_create_vm.go
+++ b/builder/virtualbox/iso/step_create_vm.go
@@ -6,9 +6,11 @@ package iso
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
+	versionUtil "github.com/hashicorp/go-version"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	vboxcommon "github.com/hashicorp/packer-plugin-virtualbox/builder/virtualbox/common"
@@ -46,11 +48,13 @@ func (s *stepCreateVM) Run(ctx context.Context, state multistep.StateBag) multis
 	commands = append(commands, []string{"modifyvm", name, "--memory", strconv.Itoa(config.HWConfig.MemorySize)})
 	commands = append(commands, []string{"modifyvm", name, "--usb", map[bool]string{true: "on", false: "off"}[config.HWConfig.USB]})
 
+	vboxVersion, _ := driver.Version()
+	audioDriverArg := audioDriverConfigurationArg(vboxVersion)
 	if strings.ToLower(config.HWConfig.Sound) == "none" {
-		commands = append(commands, []string{"modifyvm", name, "--audio-driver", config.HWConfig.Sound,
+		commands = append(commands, []string{"modifyvm", name, audioDriverArg, config.HWConfig.Sound,
 			"--audiocontroller", config.AudioController})
 	} else {
-		commands = append(commands, []string{"modifyvm", name, "--audio-driver", config.HWConfig.Sound, "--audioin", "on", "--audioout", "on",
+		commands = append(commands, []string{"modifyvm", name, audioDriverArg, config.HWConfig.Sound, "--audioin", "on", "--audioout", "on",
 			"--audiocontroller", config.AudioController})
 	}
 
@@ -130,4 +134,22 @@ func (s *stepCreateVM) Cleanup(state multistep.StateBag) {
 	if err := driver.Delete(s.vmName); err != nil {
 		ui.Error(fmt.Sprintf("Error deleting VM: %s", err))
 	}
+}
+
+func audioDriverConfigurationArg(vboxVersion string) string {
+	// The '--audio' argument was deprecated in v7.0.x giving it
+	//  the highest level of compatibility.
+	compatibleAudioArg := "--audio"
+	currentVersion, err := versionUtil.NewVersion(vboxVersion)
+	if err != nil {
+		log.Printf("[TRACE] attempt to read VBox version %q resulted in an error; using deprecated --audio argument: %s", vboxVersion, err)
+		return compatibleAudioArg
+	}
+
+	constraints, _ := versionUtil.NewConstraint(">= 7.0")
+	if currentVersion != nil && constraints.Check(currentVersion) {
+		compatibleAudioArg = "--audio-driver"
+	}
+
+	return compatibleAudioArg
 }

--- a/builder/virtualbox/iso/step_create_vm_test.go
+++ b/builder/virtualbox/iso/step_create_vm_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iso
+
+import (
+	"testing"
+
+	versionUtil "github.com/hashicorp/go-version"
+)
+
+func TestAudioDriverConfigurationArgForVersionsUsingAudioArg(t *testing.T) {
+	versions := []string{
+		"4.3",
+		"4.3.1",
+		"6.0.0",
+		"6.0.2",
+		"6.0.4",
+		"6.0.6",
+		"6.0.8",
+		"6.0.10",
+		"6.0.20",
+		"6.0.22",
+		"6.0.24",
+		"6.0.28",
+		"6.1.0",
+		"6.1.2",
+		"6.1.8",
+		"6.1.10",
+		"6.1.12",
+		"6.1.14",
+		"6.1.20",
+		"6.1.22",
+		"6.1.30",
+		"6.1.32",
+		"6.1.34",
+		"6.1.38",
+		"6.1.40",
+		"6.1.42",
+	}
+
+	for _, in := range versions {
+		in := in
+		t.Run(in, func(t *testing.T) {
+			got := audioDriverConfigurationArg(in)
+			if got != "--audio" {
+				t.Errorf("audioDriverConfigurationArg for with version %q returned %s but expected --audio", in, got)
+			}
+
+		})
+	}
+}
+func TestAudioDriverConfigurationArgForVersionsUsingAudioDriverArg(t *testing.T) {
+	versions := []string{
+		"7.0.0",
+		"7.0.2",
+		"7.0.4",
+		"7.0.6",
+		"7.0.8",
+		"7.0.10",
+		"7.0.12",
+		"7.0.14",
+		"7.0.16",
+	}
+
+	for _, in := range versions {
+		in := in
+		t.Run(in, func(t *testing.T) {
+			got := audioDriverConfigurationArg(in)
+			if got != "--audio-driver" {
+				t.Errorf("audioDriverConfigurationArg for with version %q returned %s but expected --audio-driver", in, got)
+			}
+		})
+	}
+}
+func FuzzAudioDriverConfigurationArg(f *testing.F) {
+	inputs := []string{
+		"4.0",
+		"4.1",
+		"4.2",
+		"4.3",
+		"5.0",
+		"5.1",
+		"5.2",
+		"6.0",
+		"6.1",
+		"7.0",
+	}
+	for _, in := range inputs {
+		f.Add(in)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		expected := "--audio"
+
+		got := audioDriverConfigurationArg(input)
+		versionIn, _ := versionUtil.NewVersion(input)
+		constraints, _ := versionUtil.NewConstraint(">= 7.0")
+		if versionIn != nil && constraints.Check(versionIn) {
+			expected = "--audio-driver"
+		}
+		if got != expected {
+			t.Errorf("audioDriverConfigurationArg for with version %q returned %s but expected %s", versionIn, got, expected)
+		}
+	})
+}


### PR DESCRIPTION
The latest change to replace the VBox 7.0 deprecated flag `--audio` with
the new flag `--audio-driver` resulted in a regression for 6.x versions.
This change adds version detection logic to determine the appropriate
flag to use for configuring sound on the running VM.

Closes #139 
