### PR TITLE
Allow arm chipset values

### DIFF
--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -223,7 +223,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		b.config.Chipset = "piix3"
 	}
 	switch b.config.Chipset {
-	case "piix3", "ich9":
+	case "piix3", "ich9", "armv8virtual":
 		// do nothing
 	default:
 		errs = packersdk.MultiErrorAppend(

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -223,7 +223,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		b.config.Chipset = "piix3"
 	}
 	switch b.config.Chipset {
-	case "piix3", "ich9", "armv8virtual":
+	case "piix3", "ich9", "armv8", "armv8virtual":
 		// do nothing
 	default:
 		errs = packersdk.MultiErrorAppend(


### PR DESCRIPTION
Adds the `armv8` and `armv8virtual` chipset values to the allowed value list, pulled from [VBoxManageModifyVM.cpp](https://www.virtualbox.org/browser/vbox/trunk/src/VBox/Frontends/VBoxManage/VBoxManageModifyVM.cpp#L3322)