### PR TITLE
Obtain default values for certain VM configs from Virtualbox

### DIFF
--- a/.web-docs/components/builder/iso/README.md
+++ b/.web-docs/components/builder/iso/README.md
@@ -109,6 +109,7 @@ necessary for this build to succeed and can be found further down the page.
   When set to vboxsvga, the graphics controller is VirtualBox SVGA.
   When set to vmsvga, the graphics controller is VMware SVGA.
   When set to none, the graphics controller is disabled.
+  When this configuration is omitted, the default value is determined by VirtualBox.
 
 - `gfx_vram_size` (uint) - The VRAM size to be used. By default, this is 4 MiB.
 

--- a/builder/virtualbox/common/driver.go
+++ b/builder/virtualbox/common/driver.go
@@ -57,8 +57,12 @@ type Driver interface {
 	SuppressMessages() error
 
 	// VBoxManage executes the given VBoxManage command
-	// and returns the stdout channel as string
+	// and returns an error
 	VBoxManage(...string) error
+
+	// VBoxManage executes the given VBoxManage command
+	// and returns the stdout channel as string
+	VBoxManageWithOutput(args ...string) (string, error)
 
 	// Verify checks to make sure that this driver should function
 	// properly. If there is any indication the driver can't function,

--- a/builder/virtualbox/common/driver_mock.go
+++ b/builder/virtualbox/common/driver_mock.go
@@ -54,6 +54,9 @@ type DriverMock struct {
 	VBoxManageCalls [][]string
 	VBoxManageErrs  []error
 
+	VBoxManageWithOutputCalls [][]string
+	VBoxManageWithOutputErrs  []error
+
 	VerifyCalled bool
 	VerifyErr    error
 
@@ -151,6 +154,15 @@ func (d *DriverMock) VBoxManage(args ...string) error {
 		return d.VBoxManageErrs[len(d.VBoxManageCalls)-1]
 	}
 	return nil
+}
+
+func (d *DriverMock) VBoxManageWithOutput(args ...string) (string, error) {
+	d.VBoxManageCalls = append(d.VBoxManageCalls, args)
+
+	if len(d.VBoxManageErrs) >= len(d.VBoxManageCalls) {
+		return "", d.VBoxManageErrs[len(d.VBoxManageCalls)-1]
+	}
+	return "", nil
 }
 
 func (d *DriverMock) Verify() error {

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -86,6 +86,7 @@ type Config struct {
 	// When set to vboxsvga, the graphics controller is VirtualBox SVGA.
 	// When set to vmsvga, the graphics controller is VMware SVGA.
 	// When set to none, the graphics controller is disabled.
+	// When this configuration is omitted, the default value is determined by VirtualBox.
 	GfxController string `mapstructure:"gfx_controller" required:"false"`
 	// The VRAM size to be used. By default, this is 4 MiB.
 	GfxVramSize uint `mapstructure:"gfx_vram_size" required:"false"`

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -271,15 +271,14 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			errs, errors.New("NIC type can only be 82540EM, 82543GC, 82545EM, Am79C970A, Am79C973, Am79C960 or virtio"))
 	}
 
-	if b.config.GfxController == "" {
-		b.config.GfxController = "vboxvga"
-	}
-	switch b.config.GfxController {
-	case "vboxvga", "vboxsvga", "vmsvga", "none":
-		// do nothing
-	default:
-		errs = packersdk.MultiErrorAppend(
-			errs, errors.New("Graphics controller type can only be vboxvga, vboxsvga, vmsvga, none"))
+	if b.config.GfxController != "" {
+		switch b.config.GfxController {
+		case "vboxvga", "vboxsvga", "vmsvga", "none":
+			// do nothing
+		default:
+			errs = packersdk.MultiErrorAppend(
+				errs, errors.New("Graphics controller type can only be vboxvga, vboxsvga, vmsvga, none"))
+		}
 	}
 
 	if b.config.GfxVramSize == 0 {
@@ -417,6 +416,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Comm:         &b.config.Comm,
 		},
 		new(vboxcommon.StepSuppressMessages),
+		new(stepGetVMDefaults),
 		new(stepCreateVM),
 		new(stepCreateDisk),
 		&vboxcommon.StepAttachISOs{

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -271,14 +271,12 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			errs, errors.New("NIC type can only be 82540EM, 82543GC, 82545EM, Am79C970A, Am79C973, Am79C960 or virtio"))
 	}
 
-	if b.config.GfxController != "" {
-		switch b.config.GfxController {
-		case "vboxvga", "vboxsvga", "vmsvga", "none":
-			// do nothing
-		default:
-			errs = packersdk.MultiErrorAppend(
-				errs, errors.New("Graphics controller type can only be vboxvga, vboxsvga, vmsvga, none"))
-		}
+	switch b.config.GfxController {
+	case "vboxvga", "vboxsvga", "vmsvga", "none", "":
+		// do nothing
+	default:
+		errs = packersdk.MultiErrorAppend(
+			errs, errors.New("Graphics controller type can only be vboxvga, vboxsvga, vmsvga, none"))
 	}
 
 	if b.config.GfxVramSize == 0 {

--- a/builder/virtualbox/iso/builder.go
+++ b/builder/virtualbox/iso/builder.go
@@ -380,6 +380,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	}
 
 	steps := []multistep.Step{
+		new(stepGetVMDefaults),
 		&vboxcommon.StepDownloadGuestAdditions{
 			GuestAdditionsMode:   b.config.GuestAdditionsMode,
 			GuestAdditionsURL:    b.config.GuestAdditionsURL,
@@ -416,7 +417,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Comm:         &b.config.Comm,
 		},
 		new(vboxcommon.StepSuppressMessages),
-		new(stepGetVMDefaults),
 		new(stepCreateVM),
 		new(stepCreateDisk),
 		&vboxcommon.StepAttachISOs{

--- a/builder/virtualbox/iso/builder_acc_test.go
+++ b/builder/virtualbox/iso/builder_acc_test.go
@@ -39,3 +39,81 @@ func TestAccBuilder_basic(t *testing.T) {
 	}
 	acctest.TestPlugin(t, testCase)
 }
+
+func TestAccBuilder_defaultGfxController(t *testing.T) {
+	templatePath := filepath.Join("testdata", "default_gfx.pkr.hcl")
+	bytes, err := ioutil.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("failed to load template file %s", templatePath)
+	}
+
+	testCase := &acctest.PluginTestCase{
+		Name:     "virtualbox-iso_default_gfx_test",
+		Template: string(bytes),
+		Teardown: func() error {
+			testutils.CleanupFiles("output-ubuntu_2404")
+			return nil
+		},
+		Check: func(buildCommand *exec.Cmd, logfile string) error {
+			if buildCommand.ProcessState != nil {
+				if buildCommand.ProcessState.ExitCode() != 0 {
+					return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
+				}
+			}
+			return nil
+		},
+	}
+	acctest.TestPlugin(t, testCase)
+}
+
+func TestAccBuilder_incorrectGfxController(t *testing.T) {
+	templatePath := filepath.Join("testdata", "incorrect_gfx.pkr.hcl")
+	bytes, err := ioutil.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("failed to load template file %s", templatePath)
+	}
+
+	testCase := &acctest.PluginTestCase{
+		Name:     "virtualbox-iso_incorrect_gfx_test",
+		Template: string(bytes),
+		Teardown: func() error {
+			testutils.CleanupFiles("output-ubuntu_2404")
+			return nil
+		},
+		Check: func(buildCommand *exec.Cmd, logfile string) error {
+			if buildCommand.ProcessState != nil {
+				if buildCommand.ProcessState.ExitCode() == 0 {
+					return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
+				}
+			}
+			return nil
+		},
+	}
+	acctest.TestPlugin(t, testCase)
+}
+
+func TestAccBuilder_headlessMode(t *testing.T) {
+	templatePath := filepath.Join("testdata", "headless.pkr.hcl")
+	bytes, err := ioutil.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("failed to load template file %s", templatePath)
+	}
+
+	testCase := &acctest.PluginTestCase{
+		Name:     "virtualbox-iso_headless_test",
+		Template: string(bytes),
+		Teardown: func() error {
+			testutils.CleanupFiles("output-ubuntu_2404")
+			return nil
+		},
+		Check: func(buildCommand *exec.Cmd, logfile string) error {
+			if buildCommand.ProcessState != nil {
+				if buildCommand.ProcessState.ExitCode() != 0 {
+					return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
+				}
+			}
+			return nil
+		},
+	}
+	acctest.TestPlugin(t, testCase)
+}

--- a/builder/virtualbox/iso/builder_acc_test.go
+++ b/builder/virtualbox/iso/builder_acc_test.go
@@ -6,8 +6,10 @@ package iso
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/packer-plugin-sdk/acctest"
@@ -81,8 +83,12 @@ func TestAccBuilder_incorrectGfxController(t *testing.T) {
 			return nil
 		},
 		Check: func(buildCommand *exec.Cmd, logfile string) error {
+			content, err := os.ReadFile(logfile)
+			if err != nil {
+				return fmt.Errorf("failed to read logfile: %v", err)
+			}
 			if buildCommand.ProcessState != nil {
-				if buildCommand.ProcessState.ExitCode() == 0 {
+				if buildCommand.ProcessState.ExitCode() == 0 || !strings.Contains(string(content), "Failed to construct device 'vga'") {
 					return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
 				}
 			}

--- a/builder/virtualbox/iso/step_create_vm.go
+++ b/builder/virtualbox/iso/step_create_vm.go
@@ -72,16 +72,18 @@ func (s *stepCreateVM) Run(ctx context.Context, state multistep.StateBag) multis
 		"--nictype8", config.NICType})
 
 	// Set the graphics controller, defaulting to "vboxvga" unless overridden by "vmDefaults" or config.
-	gfxController := "vboxvga"
-	vmDefaultConfigs, defaultConfigsOk := state.GetOk("vmDefaults")
-	if defaultConfigsOk && config.GfxController == "" {
-		vmDefaultConfigs := vmDefaultConfigs.(map[string]string)
-		if _, ok := vmDefaultConfigs["graphicscontroller"]; ok {
-			gfxController = vmDefaultConfigs["graphicscontroller"]
+	if config.GfxController == "" {
+		config.GfxController = "vboxvga"
+		vmDefaultConfigs, defaultConfigsOk := state.GetOk("vmDefaults")
+		if defaultConfigsOk {
+			vmDefaultConfigs := vmDefaultConfigs.(map[string]string)
+			if _, ok := vmDefaultConfigs["graphicscontroller"]; ok {
+				config.GfxController = vmDefaultConfigs["graphicscontroller"]
+			}
 		}
 	}
 
-	commands = append(commands, []string{"modifyvm", name, "--graphicscontroller", gfxController, "--vram", strconv.FormatUint(uint64(config.GfxVramSize), 10)})
+	commands = append(commands, []string{"modifyvm", name, "--graphicscontroller", config.GfxController, "--vram", strconv.FormatUint(uint64(config.GfxVramSize), 10)})
 	if config.RTCTimeBase == "UTC" {
 		commands = append(commands, []string{"modifyvm", name, "--rtcuseutc", "on"})
 	} else {

--- a/builder/virtualbox/iso/step_get_vm_defaults.go
+++ b/builder/virtualbox/iso/step_get_vm_defaults.go
@@ -1,0 +1,91 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iso
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	vboxcommon "github.com/hashicorp/packer-plugin-virtualbox/builder/virtualbox/common"
+)
+
+type stepGetVMDefaults struct {
+}
+
+func (s *stepGetVMDefaults) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(*Config)
+	driver := state.Get("driver").(vboxcommon.Driver)
+	ui := state.Get("ui").(packersdk.Ui)
+
+	baseFolder := os.TempDir()
+	vmName := fmt.Sprintf("packer_temp_vm_%d", time.Now().Unix())
+
+	// Create temp VM
+	command := []string{"createvm", "--name", vmName, "--ostype", config.GuestOSType, "--register", "--default", "--basefolder", baseFolder}
+	if err := driver.VBoxManage(command...); err != nil {
+		err := fmt.Errorf("Error creating temp VM: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Get the temp VM defaults
+	command = []string{"showvminfo", vmName, "--machinereadable"}
+	vminfo, err := driver.VBoxManageWithOutput(command...)
+	if err != nil {
+		err := fmt.Errorf("Error reading VM info: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Delete the temp VM
+	command = []string{"unregistervm", vmName, "--delete"}
+	if err := driver.VBoxManage(command...); err != nil {
+		err := fmt.Errorf("Error deleting temp VM: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	defaults, err := parseVMInfoOutput(vminfo)
+	if err != nil {
+		ui.Error("Error getting VM defaults: " + err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Store the defaults in the state bag
+	state.Put("vmDefaults", defaults)
+	ui.Message("VM defaults retrieved successfully.")
+
+	return multistep.ActionContinue
+}
+
+func parseVMInfoOutput(output string) (map[string]string, error) {
+	defaults := make(map[string]string)
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "=") {
+			parts := strings.Split(line, "=")
+			if len(parts) == 2 {
+				key := strings.Trim(strings.TrimSpace(parts[0]), `"`)
+				value := strings.Trim(strings.TrimSpace(parts[1]), `"`)
+				defaults[key] = value
+			}
+		}
+	}
+	if len(defaults) == 0 {
+		return nil, fmt.Errorf("No defaults found in VM info output")
+	}
+	return defaults, nil
+}
+
+func (s *stepGetVMDefaults) Cleanup(state multistep.StateBag) {
+	// No cleanup needed for this step
+}

--- a/builder/virtualbox/iso/step_get_vm_defaults.go
+++ b/builder/virtualbox/iso/step_get_vm_defaults.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -28,6 +29,7 @@ func (s *stepGetVMDefaults) Run(ctx context.Context, state multistep.StateBag) m
 
 	baseFolder := os.TempDir()
 	vmName := fmt.Sprintf("packer_temp_vm_%d", time.Now().Unix())
+	defer os.RemoveAll(filepath.Join(baseFolder, vmName))
 
 	// Create temp VM
 	command := []string{"createvm", "--name", vmName, "--ostype", config.GuestOSType, "--register", "--default", "--basefolder", baseFolder}

--- a/builder/virtualbox/iso/step_get_vm_defaults.go
+++ b/builder/virtualbox/iso/step_get_vm_defaults.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
-	// packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	vboxcommon "github.com/hashicorp/packer-plugin-virtualbox/builder/virtualbox/common"
 )
 

--- a/builder/virtualbox/iso/testdata/default_gfx.pkr.hcl
+++ b/builder/virtualbox/iso/testdata/default_gfx.pkr.hcl
@@ -1,0 +1,71 @@
+packer {
+  required_plugins {
+    virtualbox = {
+      version = ">= 1.0.0"
+      source  = "github.com/hashicorp/virtualbox"
+    }
+  }
+}
+source "virtualbox-iso" "ubuntu_2404" {
+  # AMD64 image
+  guest_os_type     = "Ubuntu_64"
+  iso_url           = "https://releases.ubuntu.com/24.04/ubuntu-24.04.2-live-server-amd64.iso"
+  iso_checksum      = "sha256:d6dab0c3a657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d"
+  # ARM64 image
+  # guest_os_type     = "Ubuntu_arm64"
+  # iso_url           = "https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-live-server-arm64.iso"
+  # iso_checksum      = "sha256:9fd122eedff09dc57d66e1c29acb8d7a207e2a877e762bdf30d2c913f95f03a4"
+  iso_interface     = "virtio"
+  ssh_username      = "packer"
+  ssh_password      = "packer"
+  shutdown_command  = "echo 'packer' | sudo -S shutdown -P now"
+  vm_name           = "ubuntu_vm_test"
+  memory            = 2048
+  cpus              = 2
+  # chipset           = "armv8virtual"
+  hard_drive_interface = "virtio"
+  # headless          = true
+  http_directory    = "./testdata/http_ubuntu_2404"
+  ssh_timeout       = "60m"
+  boot_wait         = "10s"
+  boot_command = [
+    "c<wait><wait><wait>",
+    "linux /casper/vmlinuz --- autoinstall ds=\"nocloud-net;seedfrom=http://{{.HTTPIP}}:{{.HTTPPort}}/\"<enter><wait>",
+    "initrd /casper/initrd<enter><wait>",
+    "boot<enter>"
+  ]
+  vboxmanage = [
+        # Firmware 
+        ["modifyvm", "{{.Name}}", "--firmware", "efi"],
+
+        # Input devices
+        ["modifyvm", "{{.Name}}", "--mouse", "ps2"],
+        ["modifyvm", "{{.Name}}", "--keyboard", "ps2"],
+
+        # Boot order
+        ["modifyvm", "{{.Name}}", "--boot1", "disk"],
+        ["modifyvm", "{{.Name}}", "--boot2", "dvd"],
+        ["modifyvm", "{{.Name}}", "--boot3", "floppy"],
+        ["modifyvm", "{{.Name}}", "--boot4", "none"],
+
+        # Network
+        ["modifyvm", "{{.Name}}", "--macaddress1", "080027F0F51D"],
+        ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
+
+        # Audio
+        ["modifyvm", "{{.Name}}", "--audio-driver", "coreaudio"],
+        ["modifyvm", "{{.Name}}", "--audio-controller", "hda"],
+        ["modifyvm", "{{.Name}}", "--audioin", "off"],
+        ["modifyvm", "{{.Name}}", "--audioout", "on"],
+
+        # Other settings
+        ["modifyvm", "{{.Name}}", "--rtcuseutc", "on"],
+        ["modifyvm", "{{.Name}}", "--usbxhci", "on"],
+        ["modifyvm", "{{.Name}}", "--clipboard-mode", "disabled"]
+      ]
+}
+
+build {
+  sources = ["source.virtualbox-iso.ubuntu_2404"]
+}
+

--- a/builder/virtualbox/iso/testdata/default_gfx.pkr.hcl
+++ b/builder/virtualbox/iso/testdata/default_gfx.pkr.hcl
@@ -53,10 +53,8 @@ source "virtualbox-iso" "ubuntu_2404" {
         ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
 
         # Audio
-        ["modifyvm", "{{.Name}}", "--audio-driver", "coreaudio"],
-        ["modifyvm", "{{.Name}}", "--audio-controller", "hda"],
         ["modifyvm", "{{.Name}}", "--audioin", "off"],
-        ["modifyvm", "{{.Name}}", "--audioout", "on"],
+        ["modifyvm", "{{.Name}}", "--audioout", "off"],
 
         # Other settings
         ["modifyvm", "{{.Name}}", "--rtcuseutc", "on"],

--- a/builder/virtualbox/iso/testdata/default_gfx.pkr.hcl
+++ b/builder/virtualbox/iso/testdata/default_gfx.pkr.hcl
@@ -27,7 +27,7 @@ source "virtualbox-iso" "ubuntu_2404" {
   # headless          = true
   http_directory    = "./testdata/http_ubuntu_2404"
   ssh_timeout       = "60m"
-  boot_wait         = "10s"
+  boot_wait         = "20s"
   boot_command = [
     "c<wait><wait><wait>",
     "linux /casper/vmlinuz --- autoinstall ds=\"nocloud-net;seedfrom=http://{{.HTTPIP}}:{{.HTTPPort}}/\"<enter><wait>",

--- a/builder/virtualbox/iso/testdata/headless.pkr.hcl
+++ b/builder/virtualbox/iso/testdata/headless.pkr.hcl
@@ -53,10 +53,8 @@ source "virtualbox-iso" "ubuntu_2404" {
         ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
 
         # Audio
-        ["modifyvm", "{{.Name}}", "--audio-driver", "coreaudio"],
-        ["modifyvm", "{{.Name}}", "--audio-controller", "hda"],
         ["modifyvm", "{{.Name}}", "--audioin", "off"],
-        ["modifyvm", "{{.Name}}", "--audioout", "on"],
+        ["modifyvm", "{{.Name}}", "--audioout", "off"],
 
         # Other settings
         ["modifyvm", "{{.Name}}", "--rtcuseutc", "on"],

--- a/builder/virtualbox/iso/testdata/headless.pkr.hcl
+++ b/builder/virtualbox/iso/testdata/headless.pkr.hcl
@@ -1,0 +1,71 @@
+packer {
+  required_plugins {
+    virtualbox = {
+      version = ">= 1.0.0"
+      source  = "github.com/hashicorp/virtualbox"
+    }
+  }
+}
+source "virtualbox-iso" "ubuntu_2404" {
+  # AMD64 image
+  guest_os_type     = "Ubuntu_64"
+  iso_url           = "https://releases.ubuntu.com/24.04/ubuntu-24.04.2-live-server-amd64.iso"
+  iso_checksum      = "sha256:d6dab0c3a657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d"
+  # ARM64 image
+  # guest_os_type     = "Ubuntu_arm64"
+  # iso_url           = "https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-live-server-arm64.iso"
+  # iso_checksum      = "sha256:9fd122eedff09dc57d66e1c29acb8d7a207e2a877e762bdf30d2c913f95f03a4"
+  iso_interface     = "virtio"
+  ssh_username      = "packer"
+  ssh_password      = "packer"
+  shutdown_command  = "echo 'packer' | sudo -S shutdown -P now"
+  vm_name           = "ubuntu_vm_test"
+  memory            = 2048
+  cpus              = 2
+  # chipset           = "armv8virtual"
+  hard_drive_interface = "virtio"
+  headless          = true
+  http_directory    = "./testdata/http_ubuntu_2404"
+  ssh_timeout       = "60m"
+  boot_wait         = "10s"
+  boot_command = [
+    "c<wait><wait><wait>",
+    "linux /casper/vmlinuz --- autoinstall ds=\"nocloud-net;seedfrom=http://{{.HTTPIP}}:{{.HTTPPort}}/\"<enter><wait>",
+    "initrd /casper/initrd<enter><wait>",
+    "boot<enter>"
+  ]
+  vboxmanage = [
+        # Firmware 
+        ["modifyvm", "{{.Name}}", "--firmware", "efi"],
+
+        # Input devices
+        ["modifyvm", "{{.Name}}", "--mouse", "ps2"],
+        ["modifyvm", "{{.Name}}", "--keyboard", "ps2"],
+
+        # Boot order
+        ["modifyvm", "{{.Name}}", "--boot1", "disk"],
+        ["modifyvm", "{{.Name}}", "--boot2", "dvd"],
+        ["modifyvm", "{{.Name}}", "--boot3", "floppy"],
+        ["modifyvm", "{{.Name}}", "--boot4", "none"],
+
+        # Network
+        ["modifyvm", "{{.Name}}", "--macaddress1", "080027F0F51D"],
+        ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
+
+        # Audio
+        ["modifyvm", "{{.Name}}", "--audio-driver", "coreaudio"],
+        ["modifyvm", "{{.Name}}", "--audio-controller", "hda"],
+        ["modifyvm", "{{.Name}}", "--audioin", "off"],
+        ["modifyvm", "{{.Name}}", "--audioout", "on"],
+
+        # Other settings
+        ["modifyvm", "{{.Name}}", "--rtcuseutc", "on"],
+        ["modifyvm", "{{.Name}}", "--usbxhci", "on"],
+        ["modifyvm", "{{.Name}}", "--clipboard-mode", "disabled"]
+      ]
+}
+
+build {
+  sources = ["source.virtualbox-iso.ubuntu_2404"]
+}
+

--- a/builder/virtualbox/iso/testdata/headless.pkr.hcl
+++ b/builder/virtualbox/iso/testdata/headless.pkr.hcl
@@ -27,7 +27,7 @@ source "virtualbox-iso" "ubuntu_2404" {
   headless          = true
   http_directory    = "./testdata/http_ubuntu_2404"
   ssh_timeout       = "60m"
-  boot_wait         = "10s"
+  boot_wait         = "20s"
   boot_command = [
     "c<wait><wait><wait>",
     "linux /casper/vmlinuz --- autoinstall ds=\"nocloud-net;seedfrom=http://{{.HTTPIP}}:{{.HTTPPort}}/\"<enter><wait>",

--- a/builder/virtualbox/iso/testdata/http_ubuntu_2404/user-data
+++ b/builder/virtualbox/iso/testdata/http_ubuntu_2404/user-data
@@ -1,0 +1,13 @@
+#cloud-config
+autoinstall:
+  version: 1
+  identity:
+    hostname: ubuntu
+    realname: ubuntu
+    username: packer
+    password: '$6$p1MmQZs.QWmMC/ax$WpR0IOxWGaS288Aoa4jKD7.IL8H5h71DhxNWQeOT3hL1kFTE3IrJk9R9o6cxJ6Ud1ATnSngjFSTxqw3KGaWzq/'
+  ssh:
+    install-server: true
+    allow-pw: true
+  packages:
+    - openssh-server

--- a/builder/virtualbox/iso/testdata/incorrect_gfx.pkr.hcl
+++ b/builder/virtualbox/iso/testdata/incorrect_gfx.pkr.hcl
@@ -1,0 +1,72 @@
+packer {
+  required_plugins {
+    virtualbox = {
+      version = ">= 1.0.0"
+      source  = "github.com/hashicorp/virtualbox"
+    }
+  }
+}
+source "virtualbox-iso" "ubuntu_2404" {
+  # AMD64 image
+  guest_os_type     = "Ubuntu_64"
+  iso_url           = "https://releases.ubuntu.com/24.04/ubuntu-24.04.2-live-server-amd64.iso"
+  iso_checksum      = "sha256:d6dab0c3a657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d"
+  # ARM64 image
+  # guest_os_type     = "Ubuntu_arm64"
+  # iso_url           = "https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-live-server-arm64.iso"
+  # iso_checksum      = "sha256:9fd122eedff09dc57d66e1c29acb8d7a207e2a877e762bdf30d2c913f95f03a4"
+  iso_interface     = "virtio"
+  ssh_username      = "packer"
+  ssh_password      = "packer"
+  shutdown_command  = "echo 'packer' | sudo -S shutdown -P now"
+  vm_name           = "ubuntu_vm_test"
+  memory            = 2048
+  cpus              = 2
+  gfx_controller   = "vboxvga" //incorrect for linux guest os
+  # chipset           = "armv8virtual"
+  hard_drive_interface = "virtio"
+  # headless          = true
+  http_directory    = "./testdata/http_ubuntu_2404"
+  ssh_timeout       = "60m"
+  boot_wait         = "10s"
+  boot_command = [
+    "c<wait><wait><wait>",
+    "linux /casper/vmlinuz --- autoinstall ds=\"nocloud-net;seedfrom=http://{{.HTTPIP}}:{{.HTTPPort}}/\"<enter><wait>",
+    "initrd /casper/initrd<enter><wait>",
+    "boot<enter>"
+  ]
+  vboxmanage = [
+        # Firmware 
+        ["modifyvm", "{{.Name}}", "--firmware", "efi"],
+
+        # Input devices
+        ["modifyvm", "{{.Name}}", "--mouse", "ps2"],
+        ["modifyvm", "{{.Name}}", "--keyboard", "ps2"],
+
+        # Boot order
+        ["modifyvm", "{{.Name}}", "--boot1", "disk"],
+        ["modifyvm", "{{.Name}}", "--boot2", "dvd"],
+        ["modifyvm", "{{.Name}}", "--boot3", "floppy"],
+        ["modifyvm", "{{.Name}}", "--boot4", "none"],
+
+        # Network
+        ["modifyvm", "{{.Name}}", "--macaddress1", "080027F0F51D"],
+        ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
+
+        # Audio
+        ["modifyvm", "{{.Name}}", "--audio-driver", "coreaudio"],
+        ["modifyvm", "{{.Name}}", "--audio-controller", "hda"],
+        ["modifyvm", "{{.Name}}", "--audioin", "off"],
+        ["modifyvm", "{{.Name}}", "--audioout", "on"],
+
+        # Other settings
+        ["modifyvm", "{{.Name}}", "--rtcuseutc", "on"],
+        ["modifyvm", "{{.Name}}", "--usbxhci", "on"],
+        ["modifyvm", "{{.Name}}", "--clipboard-mode", "disabled"]
+      ]
+}
+
+build {
+  sources = ["source.virtualbox-iso.ubuntu_2404"]
+}
+

--- a/builder/virtualbox/iso/testdata/incorrect_gfx.pkr.hcl
+++ b/builder/virtualbox/iso/testdata/incorrect_gfx.pkr.hcl
@@ -54,10 +54,8 @@ source "virtualbox-iso" "ubuntu_2404" {
         ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
 
         # Audio
-        ["modifyvm", "{{.Name}}", "--audio-driver", "coreaudio"],
-        ["modifyvm", "{{.Name}}", "--audio-controller", "hda"],
         ["modifyvm", "{{.Name}}", "--audioin", "off"],
-        ["modifyvm", "{{.Name}}", "--audioout", "on"],
+        ["modifyvm", "{{.Name}}", "--audioout", "off"],
 
         # Other settings
         ["modifyvm", "{{.Name}}", "--rtcuseutc", "on"],

--- a/builder/virtualbox/iso/testdata/incorrect_gfx.pkr.hcl
+++ b/builder/virtualbox/iso/testdata/incorrect_gfx.pkr.hcl
@@ -28,7 +28,7 @@ source "virtualbox-iso" "ubuntu_2404" {
   # headless          = true
   http_directory    = "./testdata/http_ubuntu_2404"
   ssh_timeout       = "60m"
-  boot_wait         = "10s"
+  boot_wait         = "20s"
   boot_command = [
     "c<wait><wait><wait>",
     "linux /casper/vmlinuz --- autoinstall ds=\"nocloud-net;seedfrom=http://{{.HTTPIP}}:{{.HTTPPort}}/\"<enter><wait>",

--- a/docs-partials/builder/virtualbox/iso/Config-not-required.mdx
+++ b/docs-partials/builder/virtualbox/iso/Config-not-required.mdx
@@ -34,10 +34,11 @@
   When set to sb16, the audio controller is SoundBlaster 16.
 
 - `gfx_controller` (string) - The graphics controller type to be used.
-  When set to vboxvga, the graphics controller is VirtualBox VGA. This is the default.
-  When set to vboxsvga, the graphics controller is VirtualBox SVGA.
-  When set to vmsvga, the graphics controller is VMware SVGA.
-  When set to none, the graphics controller is disabled.
+  When set to vboxvga, the graphics controller is VirtualBox VGA.  
+  When set to vboxsvga, the graphics controller is VirtualBox SVGA.  
+  When set to vmsvga, the graphics controller is VMware SVGA.  
+  When set to none, the graphics controller is disabled.  
+  When this configuration is omitted, the default value is determined by VirtualBox.
 
 - `gfx_vram_size` (uint) - The VRAM size to be used. By default, this is 4 MiB.
 

--- a/docs-partials/builder/virtualbox/iso/Config-not-required.mdx
+++ b/docs-partials/builder/virtualbox/iso/Config-not-required.mdx
@@ -34,10 +34,10 @@
   When set to sb16, the audio controller is SoundBlaster 16.
 
 - `gfx_controller` (string) - The graphics controller type to be used.
-  When set to vboxvga, the graphics controller is VirtualBox VGA.  
-  When set to vboxsvga, the graphics controller is VirtualBox SVGA.  
-  When set to vmsvga, the graphics controller is VMware SVGA.  
-  When set to none, the graphics controller is disabled.  
+  When set to vboxvga, the graphics controller is VirtualBox VGA. This is the default.
+  When set to vboxsvga, the graphics controller is VirtualBox SVGA.
+  When set to vmsvga, the graphics controller is VMware SVGA.
+  When set to none, the graphics controller is disabled.
   When this configuration is omitted, the default value is determined by VirtualBox.
 
 - `gfx_vram_size` (uint) - The VRAM size to be used. By default, this is 4 MiB.


### PR DESCRIPTION
Added ability to obtain default values for configurations by querying virtualbox. For a certain guest os type, virtualbox can provide the default config values. This is done by creating a temp VM of the given guest of type to populate the default values. This will be helpful in setting up few configs that are troublesome to users whose default values vary with guest os type.

Changes made:

Added a new step `stepGetVMDefaults` which does the following:
- Creates a temp VM with name `packer_temp_vm_<unix_timestamp>` in user's `TMPDIR`
- Calls vboxmanage showvminfo to get the vm details
- Deletes the temp VM

This new step should **not** halt or abort the build process. This config is only a recommendation from Virtualbox, and if for some reason this fails then packer should continue with the existing defaults.

Note: No resources are created for this temp VM. Only the configuration files are created on the disk which is deleted once the default values are fetched.

Currently only `gfx_controller` config is picked from defaults. The value provided in template will override this. Though we can warn the user that their gfx_controller is different from what virtualbox recommends ( to be implemented).

- Added new acceptance tests:
  - `TestAccBuilder_defaultGfxController` to validate the default graphics controller configuration when no controller is provided in template.
  - `TestAccBuilder_incorrectGfxController` to ensure incorrect graphics controller configurations fail. This would happen when an incorrect gfx controller is mentioned in template.
  - `TestAccBuilder_headlessMode` to test the headless mode configuration.



Closes #144 

