### PR TITLE
fix: update plugin installation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can find pre-built binary releases of the plugin [here](https://github.com/h
 Once you have downloaded the latest archive corresponding to your target OS,
 uncompress it to retrieve the plugin binary file corresponding to your platform.
 To install the plugin, please follow the Packer documentation on
-[installing a plugin](https://developer.hashicorp.com/packer/docs/extending/plugins/#installing-plugins).
+[installing a plugin](https://developer.hashicorp.com/packer/docs/plugins/install#manually-install-plugins-using-the-cli).
 
 
 ### From Sources
@@ -50,7 +50,7 @@ locally and run the command `go build` from the root
 directory. Upon successful compilation, a `packer-plugin-virtualbox` plugin
 binary file can be found in the root directory.
 To install the compiled plugin, please follow the official Packer documentation
-on [installing a plugin](https://developer.hashicorp.com/packer/docs/extending/plugins/#installing-plugins).
+on [installing a plugin](https://developer.hashicorp.com/packer/docs/plugins/install#manually-install-plugins-using-the-cli).
 
 
 ### Configuration


### PR DESCRIPTION
### Description
This pull request updates the documentation links in the `README.md` file. The previous links for installing plugins pointed to an outdated section of the Packer documentation (`/docs/extending/plugins/#installing-plugins`). 


### Resolved Issues

N/A


### Changes to Security Controls
**No.** This is a documentation-only change updating external URLs.