### PR TITLE
fix: align controller names for VBoxManage

### DIFF
--- a/builder/virtualbox/common/step_attach_floppy.go
+++ b/builder/virtualbox/common/step_attach_floppy.go
@@ -63,7 +63,7 @@ func (s *StepAttachFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 	// Create the floppy disk controller
 	command := []string{
 		"storagectl", vmName,
-		"--name", "Floppy Controller",
+		"--name", "Floppy",
 		"--add", "floppy",
 	}
 	if err := driver.VBoxManage(command...); err != nil {
@@ -74,7 +74,7 @@ func (s *StepAttachFloppy) Run(ctx context.Context, state multistep.StateBag) mu
 	// Attach the floppy to the controller
 	command = []string{
 		"storageattach", vmName,
-		"--storagectl", "Floppy Controller",
+		"--storagectl", "Floppy",
 		"--port", "0",
 		"--device", "0",
 		"--type", "fdd",
@@ -106,7 +106,7 @@ func (s *StepAttachFloppy) Cleanup(state multistep.StateBag) {
 
 	command := []string{
 		"storageattach", vmName,
-		"--storagectl", "Floppy Controller",
+		"--storagectl", "Floppy",
 		"--port", "0",
 		"--device", "0",
 		"--medium", "none",

--- a/builder/virtualbox/common/step_attach_isos.go
+++ b/builder/virtualbox/common/step_attach_isos.go
@@ -79,43 +79,43 @@ func (s *StepAttachISOs) Run(ctx context.Context, state multistep.StateBag) mult
 		switch diskCategory {
 		case "boot_iso":
 			// figure out controller path
-			controllerName = "IDE Controller"
+			controllerName = "IDE"
 			port = 0
 			device = 1
 			if s.ISOInterface == "sata" {
-				controllerName = "SATA Controller"
+				controllerName = "SATA"
 				port = 13
 				device = 0
 			} else if s.ISOInterface == "virtio" {
-				controllerName = "VirtIO Controller"
+				controllerName = "VirtioSCSI"
 				port = 13
 				device = 0
 			}
 			ui.Message("Mounting boot ISO...")
 		case "guest_additions":
-			controllerName = "IDE Controller"
+			controllerName = "IDE"
 			port = 1
 			device = 0
 			if s.GuestAdditionsInterface == "sata" {
-				controllerName = "SATA Controller"
+				controllerName = "SATA"
 				port = 14
 				device = 0
 			} else if s.GuestAdditionsInterface == "virtio" {
-				controllerName = "VirtIO Controller"
+				controllerName = "VirtioSCSI"
 				port = 14
 				device = 0
 			}
 			ui.Message("Mounting guest additions ISO...")
 		case "cd_files":
-			controllerName = "IDE Controller"
+			controllerName = "IDE"
 			port = 1
 			device = 1
 			if s.ISOInterface == "sata" {
-				controllerName = "SATA Controller"
+				controllerName = "SATA"
 				port = 15
 				device = 0
 			} else if s.ISOInterface == "virtio" {
-				controllerName = "VirtIO Controller"
+				controllerName = "VirtioSCSI"
 				port = 15
 				device = 0
 			}

--- a/builder/virtualbox/common/step_remove_devices.go
+++ b/builder/virtualbox/common/step_remove_devices.go
@@ -38,7 +38,7 @@ func (s *StepRemoveDevices) Run(ctx context.Context, state multistep.StateBag) m
 		ui.Message("Removing floppy drive...")
 		command := []string{
 			"storageattach", vmName,
-			"--storagectl", "Floppy Controller",
+			"--storagectl", "Floppy",
 			"--port", "0",
 			"--device", "0",
 			"--medium", "none",
@@ -59,7 +59,7 @@ func (s *StepRemoveDevices) Run(ctx context.Context, state multistep.StateBag) m
 			// Don't forget to remove the floppy controller as well
 			command = []string{
 				"storagectl", vmName,
-				"--name", "Floppy Controller",
+				"--name", "Floppy",
 				"--remove",
 			}
 			err := driver.VBoxManage(command...)

--- a/builder/virtualbox/common/step_remove_devices_test.go
+++ b/builder/virtualbox/common/step_remove_devices_test.go
@@ -43,7 +43,7 @@ func TestStepRemoveDevices_attachedIso(t *testing.T) {
 	diskUnmountCommands := map[string][]string{
 		"boot_iso": []string{
 			"storageattach", "myvm",
-			"--storagectl", "IDE Controller",
+			"--storagectl", "IDE",
 			"--port", "0",
 			"--device", "1",
 			"--type", "dvddrive",
@@ -67,7 +67,7 @@ func TestStepRemoveDevices_attachedIso(t *testing.T) {
 	if len(driver.VBoxManageCalls) != 1 {
 		t.Fatalf("bad: %#v", driver.VBoxManageCalls)
 	}
-	if driver.VBoxManageCalls[0][3] != "IDE Controller" {
+	if driver.VBoxManageCalls[0][3] != "IDE" {
 		t.Fatalf("bad: %#v", driver.VBoxManageCalls)
 	}
 }
@@ -79,7 +79,7 @@ func TestStepRemoveDevices_attachedIsoOnSata(t *testing.T) {
 	diskUnmountCommands := map[string][]string{
 		"boot_iso": []string{
 			"storageattach", "myvm",
-			"--storagectl", "SATA Controller",
+			"--storagectl", "SATA",
 			"--port", "0",
 			"--device", "1",
 			"--type", "dvddrive",
@@ -103,7 +103,7 @@ func TestStepRemoveDevices_attachedIsoOnSata(t *testing.T) {
 	if len(driver.VBoxManageCalls) != 1 {
 		t.Fatalf("bad: %#v", driver.VBoxManageCalls)
 	}
-	if driver.VBoxManageCalls[0][3] != "SATA Controller" {
+	if driver.VBoxManageCalls[0][3] != "SATA" {
 		t.Fatalf("bad: %#v", driver.VBoxManageCalls)
 	}
 }
@@ -129,10 +129,10 @@ func TestStepRemoveDevices_floppyPath(t *testing.T) {
 	if len(driver.VBoxManageCalls) != 2 {
 		t.Fatalf("bad: %#v", driver.VBoxManageCalls)
 	}
-	if driver.VBoxManageCalls[0][3] != "Floppy Controller" {
+	if driver.VBoxManageCalls[0][3] != "Floppy" {
 		t.Fatalf("bad: %#v", driver.VBoxManageCalls)
 	}
-	if driver.VBoxManageCalls[1][3] != "Floppy Controller" {
+	if driver.VBoxManageCalls[1][3] != "Floppy" {
 		t.Fatalf("bad: %#v", driver.VBoxManageCalls)
 	}
 }

--- a/builder/virtualbox/iso/step_create_disk.go
+++ b/builder/virtualbox/iso/step_create_disk.go
@@ -68,7 +68,7 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	// Add the IDE controller so we can later attach the disk.
 	// When the hard disk controller is not IDE, this device is still used
 	// by VirtualBox to deliver the guest extensions.
-	err := driver.VBoxManage("storagectl", vmName, "--name", "IDE Controller", "--add", "ide")
+	err := driver.VBoxManage("storagectl", vmName, "--name", "IDE", "--add", "ide")
 	if err != nil {
 		err := fmt.Errorf("Error creating disk controller: %s", err)
 		state.Put("error", err)
@@ -80,7 +80,7 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	// the IDE controller above because some other things (disks) require
 	// that.
 	if config.HardDriveInterface == "sata" || config.ISOInterface == "sata" {
-		if err := driver.CreateSATAController(vmName, "SATA Controller", config.SATAPortCount); err != nil {
+		if err := driver.CreateSATAController(vmName, "SATA", config.SATAPortCount); err != nil {
 			err := fmt.Errorf("Error creating disk controller: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
@@ -92,7 +92,7 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	// the VirtIO controller above because some other things (disks) require
 	// that.
 	if config.HardDriveInterface == "virtio" || config.ISOInterface == "virtio" {
-		if err := driver.CreateVirtIOController(vmName, "VirtIO Controller"); err != nil {
+		if err := driver.CreateVirtIOController(vmName, "VirtioSCSI"); err != nil {
 			err := fmt.Errorf("Error creating disk controller: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
@@ -101,14 +101,14 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	}
 
 	if config.HardDriveInterface == "scsi" {
-		if err := driver.CreateSCSIController(vmName, "SCSI Controller"); err != nil {
+		if err := driver.CreateSCSIController(vmName, "SCSI"); err != nil {
 			err := fmt.Errorf("Error creating disk controller: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
 		}
 	} else if config.HardDriveInterface == "pcie" {
-		if err := driver.CreateNVMeController(vmName, "NVMe Controller", config.NVMePortCount); err != nil {
+		if err := driver.CreateNVMeController(vmName, "NVMe", config.NVMePortCount); err != nil {
 			err := fmt.Errorf("Error creating NVMe controller: %s", err)
 			state.Put("error", err)
 			ui.Error(err.Error())
@@ -117,15 +117,15 @@ func (s *stepCreateDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	}
 
 	// Attach the disk to the controller
-	controllerName := "IDE Controller"
+	controllerName := "IDE"
 	if config.HardDriveInterface == "sata" {
-		controllerName = "SATA Controller"
+		controllerName = "SATA"
 	} else if config.HardDriveInterface == "scsi" {
-		controllerName = "SCSI Controller"
+		controllerName = "SCSI"
 	} else if config.HardDriveInterface == "virtio" {
-		controllerName = "VirtIO Controller"
+		controllerName = "VirtioSCSI"
 	} else if config.HardDriveInterface == "pcie" {
-		controllerName = "NVMe Controller"
+		controllerName = "NVMe"
 	}
 
 	nonrotational := "off"


### PR DESCRIPTION
### Description

This pull request updates the storage controller naming conventions within the VirtualBox plugin to align with the specific strings expected by `VBoxManage`. 

Specifically, this change:
* Replace "IDE Controller" with "IDE"
* Replace "SATA Controller" with "SATA"
* Replace "SCSI Controller" with "SCSI"
* Replace "Floppy Controller" with "Floppy"
* Replace "NVMe Controller" with "NVMe"
* Replace "VirtIO Controller" with "VirtioSCSI"

### Resolved Issues
Closes #56
Closes #108


### Changes to Security Controls


No changes to security controls are included in this PR.