### PR TITLE
Fix typo in shutdown message for ACPI

### DIFF
--- a/builder/virtualbox/common/step_shutdown.go
+++ b/builder/virtualbox/common/step_shutdown.go
@@ -42,7 +42,7 @@ func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 	vmName := state.Get("vmName").(string)
 
 	if s.ACPIShutdown {
-		ui.Say("Shuting down the virtual machine via ACPI power button...")
+		ui.Say("Shutting down the virtual machine via ACPI power button...")
 		if err := driver.StopViaACPI(vmName); err != nil {
 			err := fmt.Errorf("Error stopping VM: %s", err)
 			state.Put("error", err)


### PR DESCRIPTION
minor spelling issue